### PR TITLE
Fix for Photon PUN v2.29

### DIFF
--- a/MRTK Tutorials/Assets/MRTK.Tutorials.MultiUserCapabilities/Scripts/OwnershipHandler.cs
+++ b/MRTK Tutorials/Assets/MRTK.Tutorials.MultiUserCapabilities/Scripts/OwnershipHandler.cs
@@ -27,6 +27,10 @@ namespace MRTK.Tutorials.MultiUserCapabilities
         {
         }
 
+        public void OnOwnershipTransferFailed(PhotonView targetView, Player previousOwner)
+        {
+        }
+
         private void TransferControl(Player idPlayer)
         {
             if (photonView.IsMine) photonView.TransferOwnership(idPlayer);


### PR DESCRIPTION
Photon PUN v2.29 (15. March 2021) adds _IPunOwnershipCallbacks.OnOwnershipTransferFailed_. This helps react when an Ownership Transfer request failed (due to earlier changes).